### PR TITLE
feat(api): input size limit, image verify fix, brand cache, store pag…

### DIFF
--- a/api/routes/recommend.py
+++ b/api/routes/recommend.py
@@ -17,6 +17,7 @@ router = APIRouter()
 
 UPLOADS_DIR = Path("uploads")
 ALLOWED_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp"}
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MB
 
 
 class RecommendedItem(BaseModel):
@@ -43,6 +44,8 @@ async def get_recommendations(file: UploadFile = File(...)):
         raise HTTPException(status_code=400, detail="Invalid file type. Images only.")
 
     raw_bytes = await file.read()
+    if len(raw_bytes) > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="File too large. Maximum size is 10 MB.")
 
     # Sanitize: open as PIL to validate, then re-encode to PNG for storage
     try:

--- a/api/routes/search.py
+++ b/api/routes/search.py
@@ -68,7 +68,9 @@ def search_endpoint(
                     status_code=400,
                     detail="Unsupported image format. Supported: JPEG, PNG, WEBP, GIF",
                 )
-            img.verify()
+            # Re-open fresh before verify() — PIL requires an unread stream;
+            # accessing .format above may advance the internal file pointer.
+            Image.open(io.BytesIO(image_bytes)).verify()
         except HTTPException:
             raise
         except Exception as e:

--- a/api/routes/stores.py
+++ b/api/routes/stores.py
@@ -1,5 +1,6 @@
+import functools
 from typing import List, Optional
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from api.db.client import get_supabase_client
@@ -54,11 +55,10 @@ def _build_store(brand: str, entries: list) -> StoreResponse:
     )
 
 
+@functools.lru_cache(maxsize=256)
 def _resolve_brand(store_id: str) -> Optional[str]:
-    """Fetch only distinct brand names, then match by slug — avoids a full table scan."""
+    """Fetch distinct brand names and match by slug. Result is cached for the process lifetime."""
     client = get_supabase_client()
-    # Supabase doesn't expose DISTINCT natively; select brand with a high limit
-    # to get all unique values cheaply (brand column is short text, low bandwidth).
     rows = client.table("products").select("brand").execute().data or []
     seen: set[str] = set()
     for row in rows:
@@ -161,6 +161,8 @@ def get_store_items(
     store_id: str,
     category: Optional[str] = None,
     search: Optional[str] = None,
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
 ):
     brand = _resolve_brand(store_id)
     if not brand:
@@ -182,11 +184,11 @@ def get_store_items(
     product_images = _get_product_images(db_ids)
 
     seen_pids: set = set()
-    results = []
+    all_items = []
     for row in product_rows:
         pid = row["product_id"]
         if pid in seen_pids:
             continue
         seen_pids.add(pid)
-        results.append(_build_item(row, product_images, store_id))
-    return results
+        all_items.append(_build_item(row, product_images, store_id))
+    return all_items[offset : offset + limit]


### PR DESCRIPTION
…ination

- recommend.py: reject uploads over 10 MB before reading into memory
- search.py: re-open a fresh BytesIO before PIL verify() so the stream is unread (accessing .format first advances the internal pointer)
- stores.py: cache _resolve_brand() with lru_cache to avoid a full products table scan on every /stores/{id} and /stores/{id}/items call
- stores.py: add limit/offset query params to GET /stores/{id}/items